### PR TITLE
fix import __init__.py

### DIFF
--- a/src/tufw/__init__.py
+++ b/src/tufw/__init__.py
@@ -4,7 +4,7 @@ from os import execlp, getuid
 from sys import argv, executable
 
 from dialog import Dialog
-from firewall import *
+from tufw.firewall import *
 
 
 def elevate():


### PR DESCRIPTION
fix import error

Traceback (most recent call last):
  File "/usr/local/bin/tufw", line 5, in <module>
    from tufw.__init__ import main
  File "/usr/local/lib/python3.10/dist-packages/tufw/__init__.py", line 7, in <module>
    from firewall import *
ModuleNotFoundError: No module named 'firewall'